### PR TITLE
Python support update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,31 @@
 language: python
 
-python: 3.5
+python:
+    - "3.6"
+    - "3.7"
+    - "3.8"
 env:
-    - TOXENV=py27
-    - TOXENV=pypy
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
+    - TOXENV=py36
+    - TOXENV=py37
+    - TOXENV=py38
     - TOXENV=pep8
     - TOXENV=coverage
+matrix:
+    include:
+        - python: "3.6"
+          env: TOXENV=py36
+        - python: "3.7"
+          env: TOXENV=py37
+        - python: "3.8"
+          env: TOXENV=py38
+        - python: "3.8"
+          env: TOXENV=pep8
+        - python: "3.8"
+          env: TOXENV=coverage
 install:
     - pip install tox
-    - if [ "$TOXENV" = 'py34' ]; then pip install coveralls; fi
+    - if [ "$TOXENV" = 'py38' ]; then pip install coveralls; fi
 script:
     - tox -e $TOXENV
 after_success:
-    - if [ "$TOXENV" = 'py34' ]; then coveralls; fi
+    - if [ "$TOXENV" = 'py38' ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: python
 
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-env:
-    - TOXENV=py36
-    - TOXENV=py37
-    - TOXENV=py38
-    - TOXENV=pep8
-    - TOXENV=coverage
+python: 3.8
+
+cache: pip
+
 matrix:
     include:
         - python: "3.6"
@@ -22,10 +16,12 @@ matrix:
           env: TOXENV=pep8
         - python: "3.8"
           env: TOXENV=coverage
+before_install:
+    - pip install --upgrade pip setuptools
 install:
     - pip install tox
-    - if [ "$TOXENV" = 'py38' ]; then pip install coveralls; fi
+    - if [ "$TOXENV" = 'coverage' ]; then pip install coveralls; fi
 script:
     - tox -e $TOXENV
 after_success:
-    - if [ "$TOXENV" = 'py38' ]; then coveralls; fi
+    - if [ "$TOXENV" = 'coverage' ]; then coveralls; fi

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ CHANGES
 
   See https://github.com/zopefoundation/transaction/pull/68
 
+- Make Python 3.6 the minimal version
+
 0.8 (2016-12-28)
 ================
 

--- a/more/transaction/main.py
+++ b/more/transaction/main.py
@@ -76,7 +76,7 @@ def transaction_tween_factory(app, handler, transaction=transaction):
             except AbortResponse as e:
                 manager.abort()
                 return e.response
-            except:
+            except Exception:
                 ex_type, ex_value = sys.exc_info()[:2]
                 retryable = manager.manager._retryable(ex_type, ex_value)
                 manager.abort()

--- a/more/transaction/tests/test_transaction.py
+++ b/more/transaction/tests/test_transaction.py
@@ -426,4 +426,4 @@ class DummyResponse(object):
 
 
 class Conflict(TransientError):
-        pass
+    pass

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
             'coverage',
             'pytest >= 2.6.0',
             'pytest-cov',
-            'webtest'
+            'webtest',
+            'tox'
         ],
-    ))
+    )
+)

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,9 @@ setup(
         'Environment :: Web Environment',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Development Status :: 5 - Production/Stable'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,22 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,pep8,coverage
+envlist = pypy3,py36,py37,py38,pep8,coverage
 
 [testenv]
 deps = -e{toxinidir}[test]
-commands = py.test -v {posargs}
+commands = pytest -v {posargs}
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.6
 deps = {[testenv]deps}
        flake8
 
 commands = flake8 more setup.py
 
 [testenv:coverage]
-basepython = python3.5
+basepython = python3.6
 deps = {[testenv]deps}
 commands =
-    coverage run --source more.transaction -m py.test {posargs}
+    coverage run --source more.transaction -m pytest {posargs}
     coverage report -m
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,15 @@ deps = -e{toxinidir}[test]
 commands = pytest -v {posargs}
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.8
 deps = {[testenv]deps}
        flake8
+       pep8
 
 commands = flake8 more setup.py
 
 [testenv:coverage]
-basepython = python3.6
+basepython = python3.8
 deps = {[testenv]deps}
 commands =
     coverage run --source more.transaction -m pytest {posargs}


### PR DESCRIPTION
This merge request updates the minimal Python version to 3.7 and adds 3.8.

It also adds the tools required to run the tests to list of dependencies and fixes all flake8 reported issues.

Fixes #9 