### PR TITLE
Add black for Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black

--- a/more/__init__.py
+++ b/more/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/more/transaction/__init__.py
+++ b/more/transaction/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 from .main import TransactionApp, default_commit_veto
+
 # old-style naming for backwards compatibility
 from .main import TransactionApp as transaction_app

--- a/more/transaction/compat.py
+++ b/more/transaction/compat.py
@@ -1,8 +1,0 @@
-import sys
-
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    text_type = str
-else:
-    text_type = unicode  # noqa

--- a/more/transaction/main.py
+++ b/more/transaction/main.py
@@ -9,6 +9,7 @@ class TransactionApp(morepath.App):
 
 # code taken and adjusted from pyramid_tm
 
+
 def default_commit_veto(request, response):
     """
     When used as a commit veto, the logic in this function will cause the
@@ -21,10 +22,10 @@ def default_commit_veto(request, response):
 
     Otherwise the transaction will be allowed to commit.
     """
-    xtm = response.headers.get('x-tm')
+    xtm = response.headers.get("x-tm")
     if xtm is not None:
-        return xtm != 'commit'
-    return response.status.startswith(('4', '5'))
+        return xtm != "commit"
+    return response.status.startswith(("4", "5"))
 
 
 class AbortResponse(Exception):
@@ -32,12 +33,9 @@ class AbortResponse(Exception):
         self.response = response
 
 
-@TransactionApp.setting_section(section='transaction')
+@TransactionApp.setting_section(section="transaction")
 def get_transaction_settings():
-    return {
-        'attempts': 1,
-        'commit_veto': default_commit_veto
-    }
+    return {"attempts": 1, "commit_veto": default_commit_veto}
 
 
 @TransactionApp.tween_factory(over=morepath.EXCVIEW)
@@ -60,7 +58,7 @@ def transaction_tween_factory(app, handler, transaction=transaction):
                     request.reset()
                 t = manager.get()
                 if userid is not None:
-                    t.setUser(userid, '')
+                    t.setUser(userid, "")
                 t.note(str(request.path))
                 response = handler(request)
                 if manager.isDoomed():

--- a/more/transaction/main.py
+++ b/more/transaction/main.py
@@ -2,8 +2,6 @@ import sys
 import morepath
 import transaction
 
-from more.transaction.compat import text_type
-
 
 class TransactionApp(morepath.App):
     pass
@@ -63,7 +61,7 @@ def transaction_tween_factory(app, handler, transaction=transaction):
                 t = manager.get()
                 if userid is not None:
                     t.setUser(userid, '')
-                t.note(text_type(request.path))
+                t.note(str(request.path))
                 response = handler(request)
                 if manager.isDoomed():
                     raise AbortResponse(response)

--- a/more/transaction/tests/test_default_commit_veto.py
+++ b/more/transaction/tests/test_default_commit_veto.py
@@ -6,62 +6,62 @@ def callFUT(response, request=None):
 
 
 def test_it_true_500():
-    response = DummyResponse('500 Server Error')
+    response = DummyResponse("500 Server Error")
     assert callFUT(response)
 
 
 def test_it_true_503():
-    response = DummyResponse('503 Service Unavailable')
+    response = DummyResponse("503 Service Unavailable")
     assert callFUT(response)
 
 
 def test_it_true_400():
-    response = DummyResponse('400 Bad Request')
+    response = DummyResponse("400 Bad Request")
     assert callFUT(response)
 
 
 def test_it_true_411():
-    response = DummyResponse('411 Length Required')
+    response = DummyResponse("411 Length Required")
     assert callFUT(response)
 
 
 def test_it_false_200():
-    response = DummyResponse('200 OK')
+    response = DummyResponse("200 OK")
     assert not callFUT(response)
 
 
 def test_it_false_201():
-    response = DummyResponse('201 Created')
+    response = DummyResponse("201 Created")
     assert not callFUT(response)
 
 
 def test_it_false_301():
-    response = DummyResponse('301 Moved Permanently')
+    response = DummyResponse("301 Moved Permanently")
     assert not callFUT(response)
 
 
 def test_it_false_302():
-    response = DummyResponse('302 Found')
+    response = DummyResponse("302 Found")
     assert not callFUT(response)
 
 
 def test_it_false_x_tm_commit():
-    response = DummyResponse('200 OK', {'x-tm': 'commit'})
+    response = DummyResponse("200 OK", {"x-tm": "commit"})
     assert not callFUT(response)
 
 
 def test_it_true_x_tm_abort():
-    response = DummyResponse('200 OK', {'x-tm': 'abort'})
+    response = DummyResponse("200 OK", {"x-tm": "abort"})
     assert callFUT(response)
 
 
 def test_it_true_x_tm_anythingelse():
-    response = DummyResponse('200 OK', {'x-tm': ''})
+    response = DummyResponse("200 OK", {"x-tm": ""})
     assert callFUT(response)
 
 
 class DummyRequest(object):
-    path_info = '/'
+    path_info = "/"
 
     def __init__(self):
         self.environ = {}
@@ -72,7 +72,7 @@ class DummyRequest(object):
 
 
 class DummyResponse(object):
-    def __init__(self, status='200 OK', headers=None):
+    def __init__(self, status="200 OK", headers=None):
         self.status = status
         if headers is None:
             headers = {}

--- a/more/transaction/tests/test_transaction.py
+++ b/more/transaction/tests/test_transaction.py
@@ -3,18 +3,16 @@ import morepath
 from transaction import TransactionManager
 from transaction.interfaces import TransientError
 from more.transaction import TransactionApp
-from more.transaction.main import (transaction_tween_factory,
-                                   default_commit_veto)
+from more.transaction.main import transaction_tween_factory, default_commit_veto
 from webtest import TestApp as Client
 import pytest
 
 
 def test_multiple_path_variables():
-
     class TestApp(TransactionApp):
         attempts = 0
 
-    @TestApp.path('/{type}/{id}')
+    @TestApp.path("/{type}/{id}")
     class Document(object):
         def __init__(self, type, id):
             self.type = type
@@ -28,24 +26,23 @@ def test_multiple_path_variables():
         if TestApp.attempts == 1:
             raise Conflict
 
-        return 'ok'
+        return "ok"
 
-    @TestApp.setting(section='transaction', name='attempts')
+    @TestApp.setting(section="transaction", name="attempts")
     def get_retry_attempts():
         return 2
 
     client = Client(TestApp())
-    response = client.get('/document/1')
-    assert response.text == 'ok'
+    response = client.get("/document/1")
+    assert response.text == "ok"
     assert TestApp.attempts == 2
 
 
 def test_reset_unconsumed_path():
-
     class TestApp(TransactionApp):
         attempts = 0
 
-    @TestApp.path('/foo/bar')
+    @TestApp.path("/foo/bar")
     class Foo(object):
         pass
 
@@ -57,25 +54,25 @@ def test_reset_unconsumed_path():
         if TestApp.attempts == 1:
             raise Conflict
 
-        return 'ok'
+        return "ok"
 
     # if the unconsumed path is reset wrongly, it'll accidentally pick
     # up this model instead of Foo
-    @TestApp.path('/bar/foo')
+    @TestApp.path("/bar/foo")
     class Bar(object):
         pass
 
     @TestApp.view(model=Bar)
     def view_bar(self, request):
-        return 'error'
+        return "error"
 
-    @TestApp.setting(section='transaction', name='attempts')
+    @TestApp.setting(section="transaction", name="attempts")
     def get_retry_attempts():
         return 2
 
     client = Client(TestApp())
-    response = client.get('/foo/bar')
-    assert response.text == 'ok'
+    response = client.get("/foo/bar")
+    assert response.text == "ok"
     assert TestApp.attempts == 2
 
 
@@ -86,11 +83,11 @@ def test_reset_app():
     class TestApp(morepath.App):
         pass
 
-    @RootApp.mount(app=TestApp, path='/mount')
+    @RootApp.mount(app=TestApp, path="/mount")
     def mount_testapp():
         return TestApp()
 
-    @TestApp.path('/sub')
+    @TestApp.path("/sub")
     class Foo(object):
         pass
 
@@ -102,20 +99,19 @@ def test_reset_app():
         if RootApp.attempts == 1:
             raise Conflict
 
-        return 'ok'
+        return "ok"
 
-    @RootApp.setting(section='transaction', name='attempts')
+    @RootApp.setting(section="transaction", name="attempts")
     def get_retry_attempts():
         return 2
 
     client = Client(RootApp())
-    response = client.get('/mount/sub')
-    assert response.text == 'ok'
+    response = client.get("/mount/sub")
+    assert response.text == "ok"
     assert RootApp.attempts == 2
 
 
 def test_handler_exception():
-
     def handler(request):
         raise NotImplementedError
 
@@ -168,8 +164,7 @@ def test_handler_retryable_exception_defaults_to_1():
     def handler(request, count=count):
         raise Conflict
 
-    publish = transaction_tween_factory(DummyApp(),
-                                        handler, DummyTransaction())
+    publish = transaction_tween_factory(DummyApp(), handler, DummyTransaction())
 
     with pytest.raises(Conflict):
         publish(DummyRequest())
@@ -199,14 +194,14 @@ def test_handler_notes():
     publish = transaction_tween_factory(DummyApp(), handler, txn)
 
     publish(DummyRequest())
-    assert txn._note == '/'
+    assert txn._note == "/"
     assert txn.username is None
 
 
 def test_identity():
     txn = DummyTransaction()
     request = DummyRequest()
-    request.identity = morepath.Identity('foo')
+    request.identity = morepath.Identity("foo")
 
     def handler(request):
         return DummyResponse()
@@ -214,12 +209,12 @@ def test_identity():
     publish = transaction_tween_factory(DummyApp(), handler, txn)
 
     publish(request)
-    assert txn.username == ':foo'
+    assert txn.username == ":foo"
 
 
 def test_500_without_commit_veto():
     response = DummyResponse()
-    response.status = '500 Bad Request'
+    response.status = "500 Bad Request"
 
     def handler(request):
         return response
@@ -238,7 +233,7 @@ def test_500_with_default_commit_veto():
     app.settings.transaction.commit_veto = default_commit_veto
 
     response = DummyResponse()
-    response.status = '500 Bad Request'
+    response.status = "500 Bad Request"
 
     def handler(request):
         return response
@@ -254,7 +249,7 @@ def test_500_with_default_commit_veto():
 
 def test_null_commit_veto():
     response = DummyResponse()
-    response.status = '500 Bad Request'
+    response.status = "500 Bad Request"
 
     def handler(request):
         return response
@@ -376,7 +371,7 @@ class DummyTransaction(TransactionManager):
     def get(self):
         return self
 
-    def setUser(self, name, path='/'):
+    def setUser(self, name, path="/"):
         self.username = "%s:%s" % (path, name)
 
     def isDoomed(self):
@@ -399,7 +394,7 @@ class DummyTransaction(TransactionManager):
 
 
 class DummyRequest(object):
-    path = '/'
+    path = "/"
     identity = morepath.NO_IDENTITY
 
     def __init__(self):
@@ -418,7 +413,7 @@ class DummyRequest(object):
 
 
 class DummyResponse(object):
-    def __init__(self, status='200 OK', headers=None):
+    def __init__(self, status="200 OK", headers=None):
         self.status = status
         if headers is None:
             headers = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 80
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.tox
+    | env
+    | build
+    | dist
+    | bootstrap.py
+  )/
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[flake8]
+show-source = True
+ignore = E203, E731, W503, N801
+max-line-length = 88
+exclude = boostrap.py
+
+[tool:pytest]
+testpaths = more/transaction
+
+[coverage:run]
+omit = more/transaction/tests/*
+source = more/transaction
+
+[coverage:report]
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,50 @@
 import io
 from setuptools import setup, find_packages
 
-long_description = '\n'.join((
-    io.open('README.rst', encoding='utf-8').read(),
-    io.open('CHANGES.txt', encoding='utf-8').read()
-))
+long_description = "\n".join(
+    (
+        io.open("README.rst", encoding="utf-8").read(),
+        io.open("CHANGES.txt", encoding="utf-8").read(),
+    )
+)
 
 setup(
-    name='more.transaction',
-    version='0.9.dev0',
+    name="more.transaction",
+    version="0.9.dev0",
     description="transaction integration for Morepath",
     long_description=long_description,
     author="Martijn Faassen",
     author_email="faassen@startifact.com",
-    keywords='morepath sqlalchemy zodb transaction',
+    keywords="morepath sqlalchemy zodb transaction",
     license="BSD",
     url="https://github.com/morepath/more.transaction",
-    namespace_packages=['more'],
+    namespace_packages=["more"],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Environment :: Web Environment',
-        'Topic :: Software Development :: Libraries :: Application Frameworks',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Development Status :: 5 - Production/Stable'
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Environment :: Web Environment",
+        "Topic :: Software Development :: Libraries :: Application Frameworks",
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Development Status :: 5 - Production/Stable",
     ],
     install_requires=[
-        'setuptools',
-        'morepath >= 0.15',
-        'transaction >= 2.4.0',
+        "setuptools",
+        "morepath >= 0.15",
+        "transaction >= 2.4.0",
     ],
     extras_require=dict(
-        test=["pytest >= 2.9.0", "WebTest >= 2.0.14", "pytest-remove-stale-bytecode"],
+        test=[
+            "pytest >= 2.9.0",
+            "WebTest >= 2.0.14",
+            "pytest-remove-stale-bytecode",
+        ],
         pep8=["flake8", "black"],
         coverage=["pytest-cov"],
     ),

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,8 @@ setup(
         'transaction >= 2.4.0',
     ],
     extras_require=dict(
-        test=[
-            'coverage',
-            'pytest >= 2.6.0',
-            'pytest-cov',
-            'webtest',
-            'tox'
-        ],
-    )
+        test=["pytest >= 2.9.0", "WebTest >= 2.0.14", "pytest-remove-stale-bytecode"],
+        pep8=["flake8", "black"],
+        coverage=["pytest-cov"],
+    ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,25 @@
 [tox]
-envlist = pypy3,py36,py37,py38,pep8,coverage
+envlist = py36, py37, py38, pypy3, coverage, pep8
+skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
-deps = -e{toxinidir}[test]
-commands = pytest -v {posargs}
+usedevelop = True
+extras = test
+
+commands = pytest {posargs}
 
 [testenv:pep8]
 basepython = python3.8
-deps = {[testenv]deps}
-       flake8
-       pep8
+extras = pep8
 
-commands = flake8 more setup.py
+commands = flake8 more/ setup.py
+           black --check more/ setup.py
 
 [testenv:coverage]
 basepython = python3.8
-deps = {[testenv]deps}
-commands =
-    coverage run --source more.transaction -m pytest {posargs}
-    coverage report -m
+extras = test
+         coverage
 
-[pytest]
-testpaths = more
+commands = pytest --cov more/transaction --cov-fail-under=100 {posargs}
 
-[flake8]
-ignore = N801


### PR DESCRIPTION
This merge requests adds black for Python to the tools used when running the pep8 compliance tests.

It follows the morepath/reg project so that they now share their test infrastructure more.

The code has been then passed through black.